### PR TITLE
replace seaborn.apionly by seaborn

### DIFF
--- a/examples/seqlogo.ipynb
+++ b/examples/seqlogo.ipynb
@@ -34,16 +34,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/nezar/miniconda3/lib/python3.6/site-packages/seaborn/apionly.py:6: UserWarning: As seaborn no longer sets a default style on import, the seaborn.apionly module is deprecated. It will be removed in a future version.\n",
-      "  warnings.warn(msg, UserWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from __future__ import division, print_function\n",
     "from six import StringIO\n",
@@ -51,7 +42,7 @@
     "from matplotlib.patches import PathPatch\n",
     "from matplotlib.path import Path\n",
     "from matplotlib import ticker\n",
-    "import seaborn.apionly as sns\n",
+    "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import numpy as np\n",


### PR DESCRIPTION
See https://seaborn.pydata.org/whatsnew.html
In v0.8.0 (July 2017), apionly is deprecated.
In v0.10.0 (January 2020), apionly is removed.